### PR TITLE
Add Architecture Decision Records

### DIFF
--- a/adr/001-scikit-learn-api-pattern.md
+++ b/adr/001-scikit-learn-api-pattern.md
@@ -1,0 +1,27 @@
+# ADR-001: Scikit-learn-Inspired API Pattern
+
+**Status**: Accepted
+
+**Date**: 2024-01
+
+## Context
+
+The library needed an API pattern for anomaly detection that would support both stateless detectors (with explicit parameters) and stateful detectors (that learn from training data). The target users are water domain professionals who commonly work with scientific Python libraries like pandas, numpy, and scikit-learn. The pattern needed to be familiar, extensible, and support operational deployment where detectors are trained once and serialized for production use.
+
+## Decision
+
+Adopt a scikit-learn-inspired API pattern with `fit()` and `detect()` methods as the core interface for all anomaly detectors.
+
+All detectors inherit from an abstract `Detector` base class that provides `fit()` (for training) and `detect()` (for inference). Concrete detectors implement protected methods `_fit()` and `_detect()`. The `fit()` method returns `self` to enable method chaining. The method name `detect()` was chosen over scikit-learn's `predict()` to better reflect the anomaly detection domain.
+
+## Alternatives Considered
+
+**Functional API**: A simpler function-based approach like `detect_range(data, min_value=0, max_value=100)` was considered but rejected because it cannot separate training from inference, doesn't support detector serialization, and lacks composability for combining multiple detectors.
+
+**Direct scikit-learn compatibility**: Using scikit-learn's `BaseEstimator` and standard `predict()` method naming was considered but rejected to avoid heavy dependencies and to use domain-appropriate terminology (`detect` is clearer than `predict` for anomaly detection).
+
+## Consequences
+
+**Positive**: Familiar pattern for users who know scikit-learn. Extensible through base class inheritance (validation, type handling, serialization automatic for new detectors). Natural separation between training and inference phases for operational deployment.
+
+**Negative**: This API pattern is now fundamental and cannot be changed without a major version bump. Not directly compatible with scikit-learn pipelines or grid search utilities.

--- a/adr/002-pandas-series-primary-data-structure.md
+++ b/adr/002-pandas-series-primary-data-structure.md
@@ -1,0 +1,25 @@
+# ADR-002: pandas Series as Primary Data Structure
+
+**Status**: Accepted
+
+**Date**: 2021-01
+
+## Context
+
+The library needed to choose a primary data structure for time series input and output. Water domain users work with various formats including DHI's dfs0 files (via mikeio), CSV files, databases, and numpy arrays. The library needed to balance accessibility, flexibility, and ease of use.
+
+## Decision
+
+Use pandas Series as the only supported input/output format for detectors, and leave all I/O operations to the user.
+
+Detectors accept pandas Series as input and return pandas Series of boolean values (True = anomaly). The library does not provide file reading functionality or accept multiple input types. Users are responsible for converting their data format to pandas Series before detection.
+
+## Alternatives Considered
+
+**Support multiple input formats**: Could accept numpy arrays, pandas Series, and potentially dfs0 files directly. Rejected to keep the API simple and focused. Supporting multiple formats would complicate validation logic and potentially create dependencies on format-specific libraries.
+
+## Consequences
+
+**Positive**: Clear separation of concerns - library focuses solely on anomaly detection, not I/O. Simple, consistent API with single input/output type. No dependencies on format-specific libraries. Users retain flexibility to work with any data source by converting to pandas.
+
+**Negative**: Users must handle data conversion themselves. Extra step for users working with numpy arrays or dfs0 files.

--- a/adr/003-time-aware-detectors.md
+++ b/adr/003-time-aware-detectors.md
@@ -1,0 +1,27 @@
+# ADR-003: Time-Aware vs Time-Agnostic Detectors
+
+**Status**: Accepted
+
+**Date**: 2021-02
+
+## Context
+
+Some anomaly detection algorithms naturally work with sequential differences (e.g., detecting a jump of 10 units between consecutive points), while others need to account for time (e.g., detecting a rate of change of 5 units per second). Water domain applications require both types: detecting sudden level changes regardless of time spacing, and detecting flow rate anomalies that depend on the time dimension.
+
+## Decision
+
+Support both time-aware and time-agnostic detectors in the library.
+
+Time-agnostic detectors (e.g., `DiffDetector`) work with point-to-point differences using `data.diff()`, independent of the time spacing between measurements. Time-aware detectors (e.g., `GradientDetector`) calculate rates per unit time and require a `DatetimeIndex` to convert time deltas to seconds via `.dt.total_seconds()`.
+
+## Alternatives Considered
+
+**Always require DatetimeIndex**: Would force users to provide temporal information even when not needed for the detection algorithm. Rejected because some valid use cases don't have meaningful time indices (e.g., sequential sample numbers).
+
+**Convert all detectors to time-aware**: Would make all detectors use rates per second. Rejected because many water domain cases care about absolute changes regardless of time spacing (e.g., a sensor jump of 10 units is anomalous whether it happens over 1 second or 1 minute).
+
+## Consequences
+
+**Positive**: Flexibility to choose the right algorithm for the use case. Time-agnostic detectors work with any index type. Time-aware detectors properly handle irregular sampling rates common in operational monitoring.
+
+**Negative**: Users must understand which detectors require DatetimeIndex. API inconsistency between detector types. Error messages appear at detection time rather than initialization.

--- a/adr/README.md
+++ b/adr/README.md
@@ -1,0 +1,33 @@
+# Architecture Decision Records (ADRs)
+
+This directory contains Architecture Decision Records (ADRs) for the tsod project. ADRs help new developers (and future maintainers) understand why the codebase is structured the way it is.
+
+## What is an ADR?
+
+An Architecture Decision Record (ADR) documents a significant architectural decision made in the project, including the context, the decision itself, alternatives considered, and consequences.
+
+## Format
+
+Each ADR follows this structure:
+
+- **Status**: Draft, Accepted, Superseded, or Deprecated
+- **Date**: When the decision was made or drafted
+- **Context**: The problem or requirement that prompted this decision
+- **Decision**: What was chosen and why
+- **Alternatives Considered**: Other options that were evaluated
+- **Consequences**: Trade-offs, benefits, and implications
+
+## Index
+
+- [ADR-001](001-scikit-learn-api-pattern.md) - Scikit-learn-inspired API pattern
+- [ADR-002](002-pandas-series-primary-data-structure.md) - pandas Series as primary data structure
+- [ADR-003](003-time-aware-detectors.md) - Time-aware vs time-agnostic detectors
+
+## Contributing
+
+When making significant architectural changes, please:
+
+1. Create a new ADR in Draft status
+2. Discuss with the team
+3. Update to Accepted status once implemented
+4. Update this index with a link to the new ADR


### PR DESCRIPTION
## Summary

Introduces Architecture Decision Record (ADR) documentation following the same pattern as ModelSkill. Documents the three fundamental architectural decisions that define tsod's design:

- **ADR-001**: Scikit-learn-inspired API pattern - Why we use fit/detect methods
- **ADR-002**: pandas Series as primary data structure - Why we only accept pandas Series for I/O
- **ADR-003**: Time-aware vs time-agnostic detectors - Why some detectors require DatetimeIndex

These ADRs focus exclusively on hard-to-change decisions that would require major version changes to modify. They provide context for new contributors and future maintainers about why the library is structured the way it is.